### PR TITLE
Fix integer overflow in utf{16,32}_to_utf8_length

### DIFF
--- a/libutils/Unicode.cpp
+++ b/libutils/Unicode.cpp
@@ -17,6 +17,7 @@
 #include <log/log.h>
 #include <utils/Unicode.h>
 
+#include <limits.h>
 #include <stddef.h>
 
 #if defined(_WIN32)
@@ -178,7 +179,15 @@ ssize_t utf32_to_utf8_length(const char32_t *src, size_t src_len)
     size_t ret = 0;
     const char32_t *end = src + src_len;
     while (src < end) {
-        ret += utf32_codepoint_utf8_length(*src++);
+        size_t char_len = utf32_codepoint_utf8_length(*src++);
+        if (SSIZE_MAX - char_len < ret) {
+            // If this happens, we would overflow the ssize_t type when
+            // returning from this function, so we cannot express how
+            // long this string is in an ssize_t.
+            android_errorWriteLog(0x534e4554, "37723026");
+            return -1;
+        }
+        ret += char_len;
     }
     return ret;
 }
@@ -438,14 +447,23 @@ ssize_t utf16_to_utf8_length(const char16_t *src, size_t src_len)
     size_t ret = 0;
     const char16_t* const end = src + src_len;
     while (src < end) {
+        size_t char_len;
         if ((*src & 0xFC00) == 0xD800 && (src + 1) < end
                 && (*(src + 1) & 0xFC00) == 0xDC00) {
             // surrogate pairs are always 4 bytes.
-            ret += 4;
+            char_len = 4;
             src += 2;
         } else {
-            ret += utf32_codepoint_utf8_length((char32_t) *src++);
+            char_len = utf32_codepoint_utf8_length((char32_t)*src++);
         }
+        if (SSIZE_MAX - char_len < ret) {
+            // If this happens, we would overflow the ssize_t type when
+            // returning from this function, so we cannot express how
+            // long this string is in an ssize_t.
+            android_errorWriteLog(0x534e4554, "37723026");
+            return -1;
+        }
+        ret += char_len;
     }
     return ret;
 }


### PR DESCRIPTION
Without an explicit check, the return value can wrap around and return
a value that is far too small to hold the data from the resulting
conversion.

No CTS test is provided because it would need to allocate at least
SSIZE_MAX / 2 bytes of UTF-16 data, which is unreasonable on 64-bit
devices.

Bug: 37723026
Test: run cts -p android.security
Change-Id: I56ba5e31657633b7f33685dd8839d4b3b998e586
(cherry picked from commit 47efc676c849e3abf32001d66e2d6eb887e83c48)